### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/components/settings/BackupRestoreSettings.tsx
+++ b/components/settings/BackupRestoreSettings.tsx
@@ -254,6 +254,10 @@ export function BackupRestoreSettings() {
    * Parse XML to backup data
    */
   const parseXML = (xml: string): BackupData => {
+    // Prevent parsing dangerous XML constructs (e.g., DOCTYPE, external entities)
+    if (/<!DOCTYPE/i.test(xml)) {
+      throw new Error('Unsafe XML: DOCTYPE is not allowed');
+    }
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, 'application/xml');
 


### PR DESCRIPTION
Potential fix for [https://github.com/jhl-labs/sepilot_desktop/security/code-scanning/2](https://github.com/jhl-labs/sepilot_desktop/security/code-scanning/2)

To mitigate the risk, we should ensure that the uploaded XML file is safe for parsing. Specifically:

1. Validate the XML input: Immediately after parsing, check not just for structural validity, but also specifically disallow problematic features such as DOCTYPE declarations, external entities, or anything that could lead to browser security issues.
2. Harden XML parsing: Use a regular expression or DOM inspection to block/strip the `<!DOCTYPE>` declaration and make sure no external entities exist before passing the text to `DOMParser`.
3. Optionally, consider parsing the XML on the server side or using a minimal, safe, custom parser for the required data shape, rather than parsing arbitrary untrusted XML in the browser.

For this code, one practical fix is to detect and reject any XML files containing a DOCTYPE declaration before parsing. The relevant area is in the `parseXML` function in `components/settings/BackupRestoreSettings.tsx`, lines 256–347. We should add a check at the start of `parseXML` to reject/invalidate any XML containing the (case-insensitive) string `<!DOCTYPE`.

No additional methods or imports are required; this can be implemented as a simple string check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
